### PR TITLE
Potential fix for code scanning alert no. 16: Missing rate limiting

### DIFF
--- a/sovereign-woodcraft/backend/package.json
+++ b/sovereign-woodcraft/backend/package.json
@@ -22,7 +22,8 @@
     "express-async-handler": "^1.2.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.16.5",
-    "multer": "^2.0.2"
+    "multer": "^2.0.2",
+    "express-rate-limit": "^8.0.1"
   },
   "devDependencies": {
     "nodemon": "^3.1.4"

--- a/sovereign-woodcraft/backend/routes/logRoutes.js
+++ b/sovereign-woodcraft/backend/routes/logRoutes.js
@@ -1,10 +1,17 @@
 import express from 'express';
 import { getLogs } from '../controllers/logController.js';
 import { protect, admin } from '../middleware/authMiddleware.js';
+import rateLimit from 'express-rate-limit';
 
 const router = express.Router();
 
-router.route('/').get(protect, admin, getLogs);
+// Rate limiter: max 100 requests per 15 minutes per IP
+const logsLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+
+router.route('/').get(protect, admin, logsLimiter, getLogs);
 router.get('/')
 
 export default router;


### PR DESCRIPTION
Potential fix for [https://github.com/Jnanamithran/sovereign-woodcraft-v2/security/code-scanning/16](https://github.com/Jnanamithran/sovereign-woodcraft-v2/security/code-scanning/16)

To fix the problem, we should add rate limiting middleware to the Express router handling the `/` GET request for logs. The most straightforward way is to use the popular `express-rate-limit` package. We should import `express-rate-limit`, configure a limiter (for example, limiting the number of requests per IP per time window), and apply it specifically to the `getLogs` route.

This requires: 
- Adding an import for `express-rate-limit`.
- Creating a rate limiter instance (e.g., max 100 requests per 15 minutes).
- Adding the limiter as a middleware to line 7 in the route definition: `router.route('/').get(protect, admin, limiter, getLogs);`

All changes should occur in the provided file, and only within the shown code region.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
