### PR TITLE
Potential fix for code scanning alert no. 14: Missing rate limiting

### DIFF
--- a/sovereign-woodcraft/backend/routes/productRoutes.js
+++ b/sovereign-woodcraft/backend/routes/productRoutes.js
@@ -1,4 +1,5 @@
 import express from 'express';
+import rateLimit from 'express-rate-limit';
 import { 
     getProducts, 
     getProductById, 
@@ -11,6 +12,15 @@ import {
 import { protect, admin } from '../middleware/authMiddleware.js'; // For security
 
 const router = express.Router();
+
+// Rate limiter for delete requests (admin-only)
+const deleteLimiter = rateLimit({
+    windowMs: 1 * 60 * 1000, // 1 minute window
+    max: 5, // limit each IP to 5 delete requests per minute
+    message: "Too many delete requests, please try again later.",
+    standardHeaders: true, 
+    legacyHeaders: false,
+});
 
 // Routes for fetching products and creating a new one
 router.route('/')
@@ -27,6 +37,6 @@ router.get('/featured', getFeaturedProducts);
 router.route('/:id')
     .get(getProductById)
     .put(protect, admin, updateProduct)    // Update a product (admin only)
-    .delete(protect, admin, deleteProduct); // Delete a product (admin only)
+    .delete(protect, admin, deleteLimiter, deleteProduct); // Delete a product (admin only, rate-limited)
 
 export default router;


### PR DESCRIPTION
Potential fix for [https://github.com/Jnanamithran/sovereign-woodcraft-v2/security/code-scanning/14](https://github.com/Jnanamithran/sovereign-woodcraft-v2/security/code-scanning/14)

To fix the problem, we should add rate-limiting middleware to the affected route (the `.delete()` handler for `/:id`). The best way to do this is to use a well-known middleware, such as `express-rate-limit`. Since we only have code for this router file, we'll:

1. Import `express-rate-limit`.
2. Define a rate limiter with suitable limits for an admin-level delete operation (e.g., allow 5 deletes per minute per IP).
3. Apply this rate limiter specifically to the `.delete()` handler for the route `/:id`.
4. Code edits are restricted to sovereign-woodcraft/backend/routes/productRoutes.js, so all adjustments will be in this file.

We should add the import at the top, define the limiter before routes, and insert it as a middleware specifically for the delete route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
