### PR TITLE
Potential fix for code scanning alert no. 13: Missing rate limiting

### DIFF
--- a/sovereign-woodcraft/backend/routes/productRoutes.js
+++ b/sovereign-woodcraft/backend/routes/productRoutes.js
@@ -1,4 +1,5 @@
 import express from 'express';
+import rateLimit from 'express-rate-limit';
 import { 
     getProducts, 
     getProductById, 
@@ -9,6 +10,15 @@ import {
     getProductsForManagement // Import the new controller function
 } from '../controllers/productController.js';
 import { protect, admin } from '../middleware/authMiddleware.js'; // For security
+
+// Rate limiter for admin product modification (update/delete)
+const adminProductLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 20, // max 20 requests per window per IP for product updates
+    message: 'Too many product update requests from this IP, please try again after 15 minutes',
+    standardHeaders: true,
+    legacyHeaders: false,
+});
 
 const router = express.Router();
 
@@ -26,7 +36,7 @@ router.get('/featured', getFeaturedProducts);
 // Routes for a single product by its ID
 router.route('/:id')
     .get(getProductById)
-    .put(protect, admin, updateProduct)    // Update a product (admin only)
+    .put(adminProductLimiter, protect, admin, updateProduct)    // Update a product (admin only, rate-limited)
     .delete(protect, admin, deleteProduct); // Delete a product (admin only)
 
 export default router;


### PR DESCRIPTION
Potential fix for [https://github.com/Jnanamithran/sovereign-woodcraft-v2/security/code-scanning/13](https://github.com/Jnanamithran/sovereign-woodcraft-v2/security/code-scanning/13)

The best way to fix this issue is to apply a rate-limiting middleware to the routes that perform database access and might be sensitive to abuse, such as the product update route. In Express, the recommended approach is to use the well-known `express-rate-limit` package. You should import `express-rate-limit`, configure a rate limiter (e.g., allow up to X requests per Y period per IP), and apply it specifically to the `PUT /:id` route (or more broadly, if desired). The change involves updating `sovereign-woodcraft/backend/routes/productRoutes.js` by: 
1. Importing `express-rate-limit`;
2. Defining a suitable rate limiter (for admin operations a lower threshold is typical, e.g. 10-20 requests per 15 min);
3. Adding the rate-limiting middleware to the `.put()` handler on line 29, before the existing authentication/authorization middleware.

No changes to route functionality are needed except to introduce the rate limiting.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
